### PR TITLE
Add `sveltekit:prefetch` to nav

### DIFF
--- a/src/lib/PageComponents/Header.svelte
+++ b/src/lib/PageComponents/Header.svelte
@@ -23,7 +23,7 @@
             <!-- * Here we are loading 'links' as by destructing the inner arrays into 'text' and 'link'-->
             <div class="navItem">
                 <!-- * Then we just create anchor tags that have href to link and text as text -->
-                <a class="navLink" href={link}>{text}</a>
+                <a class="navLink" href={link} sveltekit:prefetch>{text}</a>
             </div>
         {/each}
     </nav>

--- a/src/lib/Reusable/Checkies.svelte
+++ b/src/lib/Reusable/Checkies.svelte
@@ -136,7 +136,7 @@
         padding: 10px 20px;
         border: none;
         color: aliceblue;
-        margin-right: 10px
+        margin-right: 5px;
     }
 
     .show {
@@ -160,7 +160,7 @@
     
     .checkie {
         border-top: 5px hsl(208, 26%, 20%) solid;
-        padding: 5px;
+        padding: 5px 10px;
         display: flex;
         border-top-left-radius: 20px;
         border-top-right-radius: 20px;

--- a/src/lib/Reusable/Checkies.svelte
+++ b/src/lib/Reusable/Checkies.svelte
@@ -1,6 +1,5 @@
 <script>
     import Linkpagebox from "$lib/Reusable/Linkpagebox.svelte";
-    import { each } from "svelte/internal";
     import {locale} from "$lib/translations/i18n";
     export let title = "no title specified";
     export let text = "no text provided";

--- a/src/lib/Reusable/Checkies.svelte
+++ b/src/lib/Reusable/Checkies.svelte
@@ -122,7 +122,7 @@
     }   
 
     #tag {
-        margin: 10px 0px 5px 0px;
+		margin-right: 6px;
     }
 
     .checkbox {

--- a/src/routes/checkies/+page.svelte
+++ b/src/routes/checkies/+page.svelte
@@ -31,7 +31,7 @@
     <div class="behindCheckies">
         <h2>Checkies:</h2>
         {#each checkies as checkie, i}
-            <Checkies title={checkie.name} tagsObject= {tags} linkTagsObject={links.tags} tags={checkie.tags} text={checkie.text} relevantLinks={relevantLinksData[i]} ></Checkies>
+            <Checkies title={checkie.name} tagsObject={tags} linkTagsObject={links.tags} tags={checkie.tags} text={checkie.text} relevantLinks={relevantLinksData[i]} ></Checkies>
         {/each}
     </div>
 </main>


### PR DESCRIPTION
`sveltekit:prefetch` is used to fetch the page on hover so that the page starts loading before clicking and therefore navigation feels faster. I think it's a good idea in the nav to make the site snappier.


(Also I kinda accidentally commited removing a space, but that space shouldn't be there anyways so I don't think it's too bad) 

Also now I made some layout improvements and accidentally did it in the same pull request. 